### PR TITLE
Fixed a bug that for single node cluster initialization, it is waiting…

### DIFF
--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -169,6 +169,7 @@ func (m *Manager) pollJoinReadyAll(epnode *Node) error {
 		go n.PollJoinReady(chErr)
 		size++
 	}
+	if size == 0 { return nil }
 	finished := 0
 
 	for {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -227,7 +227,9 @@ func Start() {
 
 	// Start listening now
 	log.Printf("Daemon is starting on %s", restServer.Addr)
-	restServer.ListenAndServe()
+	if err = restServer.ListenAndServe(); err != nil {
+		log.Printf("Error:%s", err)
+	}
 
 	// Signal all our running goroutines to shut down
 	shutdownSig <- struct{}{}


### PR DESCRIPTION
… for channel forever

Prints error message when the cbdyncluster port is in use