### PR TITLE
Added version API which will show current version of cbdynclusterd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+#-------------------------------------------------------------------------------
+# VARIABLES
+#-------------------------------------------------------------------------------
+
+NAME      = cbdynclusterd
+DIST_NAME ?= $(NAME)
+MAIN_PATH = github.com/couchbaselabs/cbdynclusterd
+
+VERSION = $(shell git describe --always --tags)
+GOFLAGS = -ldflags "-X ${MAIN_PATH}/daemon.Version=${VERSION}"
+
+GOOS 	?= darwin
+GOARCH  ?= amd64
+
+#-------------------------------------------------------------------------------
+# SPECIAL
+#-------------------------------------------------------------------------------
+
+.DEFAULT: default
+.PHONY: default
+default: clean build
+
+.PHONY: all
+all: clean build-all
+
+.PHONY: release
+release: clean build-all
+
+#-------------------------------------------------------------------------------
+# EXECUTABLE
+#-------------------------------------------------------------------------------
+
+.PHONY: clean
+clean:
+	go clean .
+	rm -rf bin
+
+.PHONY: run
+run:
+	./bin/$(NAME).$(GOOS)_$(GOARCH)
+
+.PHONY: install
+install:
+	cp bin/$(NAME).$(GOOS)_$(GOARCH) ~/bin/$(DIST_NAME)
+
+#-------------------------------------------------------------------------------
+# BUILD
+#-------------------------------------------------------------------------------
+
+.PHONY: build
+build:
+	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o bin/$(NAME).$(GOOS)_$(GOARCH)
+	chmod +x bin/$(NAME).$(GOOS)_$(GOARCH)
+.PHONY: build-all
+build-all: build-mac build-linux
+
+.PHONY: build-mac
+build-mac: GOOS=darwin
+build-mac:
+	@$(MAKE) build GOOS=$(GOOS) GOARCH=$(GOARCH)
+
+.PHONY: build-linux
+build-linux: GOOS=linux
+build-linux:
+	@$(MAKE) build GOOS=$(GOOS) GOARCH=$(GOARCH)

--- a/daemon/clusters.go
+++ b/daemon/clusters.go
@@ -26,6 +26,7 @@ type ClusterOptions struct {
 
 type Node struct {
 	ContainerID          string
+	ContainerName        string
 	State                string
 	Name                 string
 	InitialServerVersion string
@@ -97,7 +98,7 @@ func getAllClusters(ctx context.Context) ([]*Cluster, error) {
 
 		var nodes []*Node
 		for _, container := range containers {
-			eth0Net := container.NetworkSettings.Networks["macvlan0"]
+			eth0Net := container.NetworkSettings.Networks[NetworkName]
 			if eth0Net == nil {
 				// This is a little hack to make sure wierd stuff doesn't stop the node
 				// from showing up in the nodes list
@@ -112,6 +113,7 @@ func getAllClusters(ctx context.Context) ([]*Cluster, error) {
 
 			nodes = append(nodes, &Node{
 				ContainerID:          container.ID[0:12],
+				ContainerName:        container.Names[0],
 				State:                container.State,
 				Name:                 container.Labels["com.couchbase.dyncluster.node_name"],
 				InitialServerVersion: container.Labels["com.couchbase.dyncluster.initial_server_version"],

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -10,12 +10,115 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/mitchellh/go-homedir"
+	"fmt"
+	"path"
+	"github.com/pelletier/go-toml"
+	"io/ioutil"
+	goflag "flag"
+	"github.com/spf13/pflag"
 )
 
 var docker *client.Client
 var metaStore *MetaDataStore
 var systemCtx context.Context
 var dockerRegistry = "dockerhub.build.couchbase.com" // TODO: get this from a config
+var cfgFile string
+var cfgFileName = ".cbdynclusterd.toml"
+var dockerRegistryFlag, dockerHostFlag, dockerPortFlag, dnsHostFlag string
+
+
+var rootCmd = &cobra.Command{
+	Use:   "cbdynclusterd",
+	Short: "Launches cbdyncluster daemon",
+	Long: "Launches cbdyncluster daemon",
+	Run: func(cmd *cobra.Command, args []string) {
+		Start()
+	},
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	goflag.CommandLine.Parse([]string{})
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/"+cfgFileName+")")
+	rootCmd.PersistentFlags().StringVar(&dockerRegistryFlag, "docker-registry", "dockerhub.build.couchbase.com", "docker registry to pull/push images")
+	rootCmd.PersistentFlags().StringVar(&dockerHostFlag, "docker-host", "172.23.104.43", "docker host where containers are running")
+	rootCmd.PersistentFlags().StringVar(&dockerPortFlag, "docker-port", "2376", "docker port where docker daemon is running on")
+	rootCmd.PersistentFlags().StringVar(&dnsHostFlag, "dns-host", "172.23.111.128", "dns server IP")
+}
+
+func initConfig() {
+
+
+	if cfgFile != "" {
+		// if user specified the config file, use it
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// use default config file
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		configFile := path.Join(home, cfgFileName)
+		viper.SetConfigFile(configFile)
+
+		// Read configuration file. If not exists, create and set with default values
+		if _, err := os.Stat(configFile); os.IsNotExist(err) {
+			if err = createConfigFile(configFile); err != nil {
+				fmt.Printf("Error:%s\n", err)
+				return
+			}
+		}
+
+	}
+
+	viper.AutomaticEnv()
+	viper.ReadInConfig()
+
+	dockerRegistryFlag = getArg("docker-registry")
+	dockerHostFlag     = getArg("docker-host")
+	dockerPortFlag     = getArg("docker-port")
+	dnsHostFlag        = getArg("dns-host")
+
+}
+
+func createConfigFile(configFile string) error {
+	tmap, err := toml.TreeFromMap(nil)
+	if err != nil { return err }
+
+	tmap.Set("docker-registry", dockerRegistryFlag)
+	tmap.Set("docker-host", dockerHostFlag)
+	tmap.Set("docker-port", dockerPortFlag)
+	tmap.Set("dns-host", dnsHostFlag)
+
+	return ioutil.WriteFile(configFile, []byte(tmap.String()), 0644)
+}
+
+func getArg(arg string) string {
+	var val string
+	if rootCmd.PersistentFlags().Changed(arg) {
+		// read from commandline option
+		val, _ = rootCmd.PersistentFlags().GetString(arg)
+	} else {
+		// read from config
+		val = viper.GetString(arg)
+	}
+
+	return val
+}
 
 func openMeta() error {
 	meta := &MetaDataStore{}
@@ -32,7 +135,7 @@ func openMeta() error {
 func connectDocker() error {
 	var clientOpts []func(*client.Client) error
 	clientOpts = append(clientOpts, client.FromEnv)
-	clientOpts = append(clientOpts, client.WithHost("http://172.23.104.43:2376")) // TODO: get this from a config
+	clientOpts = append(clientOpts, client.WithHost("tcp://"+dockerHostFlag+":"+dockerPortFlag))
 	clientOpts = append(clientOpts, client.WithVersion("1.38"))
 
 	cli, err := client.NewClientWithOpts(clientOpts...)

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -20,8 +20,8 @@ import (
 var (
 	IniFile        *string
 	Slowlog        bool
-	RestRetry = 10
-	RestTimeout = 1000*time.Second
+	RestRetry = 60
+	RestTimeout = 60*time.Second
 	WaitTimeout = 30*time.Second
 	restInterval = 3*time.Second
 	PattActual, _ = regexp.Compile("\\s*vb_active_itm_memory:\\s*([0-9]+)")
@@ -62,6 +62,8 @@ const (
 	PSettingsIndexes   = "/settings/indexes"
 	PN1ql              = "/query"
 	PFts               = "/api/index"
+
+	Domain             = "/domain"
 
 	DockerFilePath = "deps/sdkqe-resource/dockerfiles/"
 
@@ -118,6 +120,7 @@ type RestCall struct {
 	Cred *Cred
 	Body string
 	Header map[string]string
+	ContentType string
 }
 
 func Usage() {
@@ -332,7 +335,11 @@ func GetResponse(params *RestCall) (string, error) {
 	req, err := http.NewRequest(method, url, strings.NewReader(postBody))
 	if err != nil { return "", err }
 	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(login.Username+":"+login.Password)))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	contentType := "application/x-www-form-urlencoded"
+	if params.ContentType != "" {
+		contentType = params.ContentType
+	}
+	req.Header.Set("Content-Type", contentType)
 	for k,v := range header {
 		req.Header.Set(k, v)
 	}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"github.com/couchbaselabs/cbdynclusterd/daemon"
-	"flag"
 )
 
 func main() {
-	flag.Parse()
-	daemon.Start()
+	daemon.Execute()
 }


### PR DESCRIPTION
Added hostname attached to the container. When container is created, daemon calls REST API to DNS container to register it's hostname. DNS hostname is configurable
Added docker-host API which will return docker host that cbdyncluster is connecting
Reads docker-host, docker-port, docker-registry and dns-host from config, if config does not exists, it will created one with default values.
Fixed bug on docker-host command that showed host of cbdynclusterd if it is running out side of docker host
Adjusted REST timeout to 60 Seconds and number of max retry to 60
Node contains container's name which is used as hostname of the container
Code clean up for glog integration
Couple of hard coded values are read from config