### PR TITLE
Add cluster-id option to allocate

### DIFF
--- a/daemon/clusters.go
+++ b/daemon/clusters.go
@@ -20,8 +20,9 @@ func newRandomClusterID() string {
 }
 
 type ClusterOptions struct {
-	Timeout time.Duration
-	Nodes   []NodeOptions
+	Timeout   time.Duration
+	Nodes     []NodeOptions
+	CLusterID string
 }
 
 type Node struct {
@@ -159,7 +160,10 @@ func allocateCluster(ctx context.Context, opts ClusterOptions) (string, error) {
 		return "", errors.New("cannot allocate clusters with more than 10 nodes")
 	}
 
-	clusterID := newRandomClusterID()
+	clusterID := opts.CLusterID
+	if clusterID == "" {
+		clusterID = newRandomClusterID()
+	}
 	timeoutTime := time.Now().Add(1 * time.Hour) // TODO: use the opts.Timeout
 
 	meta := ClusterMeta{

--- a/daemon/restserver.go
+++ b/daemon/restserver.go
@@ -236,9 +236,10 @@ type CreateClusterSetupJSON struct {
 }
 
 type CreateClusterJSON struct {
-	Timeout string                  `json:"timeout"`
-	Nodes   []CreateClusterNodeJSON `json:"nodes"`
-	Setup   CreateClusterNodeJSON   `json:"setup"`
+	Timeout   string                  `json:"timeout"`
+	Nodes     []CreateClusterNodeJSON `json:"nodes"`
+	Setup     CreateClusterNodeJSON   `json:"setup"`
+	ClusterID string                  `json:"cluster_id"`
 }
 
 type NewClusterJSON struct {
@@ -260,7 +261,8 @@ func HttpCreateCluster(w http.ResponseWriter, r *http.Request) {
 	}
 
 	clusterOpts := ClusterOptions{
-		Timeout: 1 * time.Hour,
+		Timeout:   1 * time.Hour,
+		CLusterID: reqData.ClusterID,
 	}
 
 	if reqData.Timeout != "" {


### PR DESCRIPTION
This mostly just makes dev easier being able to rerun bash
commands using the same id over deletions/recreations.