### PR TITLE
Add Net Admin capability to docker containers

### DIFF
--- a/daemon/nodes.go
+++ b/daemon/nodes.go
@@ -131,6 +131,7 @@ func allocateNode(ctx context.Context, clusterID string, timeout time.Time, opts
 		AutoRemove:  true,
 		NetworkMode: container.NetworkMode(NetworkName),
 		DNS:         dns,
+		CapAdd:      []string{"NET_ADMIN"},
 	}, nil, containerName)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Needed for Sdkd tests. Could make it an option, if desired, but didn't think it necessary.