### PR TITLE
EC2 AMI changes

### DIFF
--- a/packerfiles/aws-amzn2.pkr.hcl
+++ b/packerfiles/aws-amzn2.pkr.hcl
@@ -60,11 +60,11 @@ source "amazon-ebs" "amzn2" {
   launch_block_device_mappings {
     device_name           = "/dev/xvda"
     volume_size           = 40
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     delete_on_termination = true
   }
   snapshot_tags = {
-    linked_ami = var.ami_name
+    Name = var.ami_name
   }
 }
 
@@ -77,6 +77,7 @@ build {
       "curl -u ${var.download_username}:${var.download_password} -o ${var.build_pkg} -s ${local.build_url}",
       "sudo yum install -y ${var.build_pkg}",
       "rm ${var.build_pkg}",
+      "sudo usermod -a -G couchbase ec2-user"
     ]
   }
 }

--- a/service/ec2/ec2service.go
+++ b/service/ec2/ec2service.go
@@ -176,12 +176,16 @@ func (s *EC2Service) allocateNode(ctx context.Context, clusterID string, timeout
 	}
 
 	ami := out.Images[0].ImageId
+	instanceType := types.InstanceTypeM4Xlarge
+	if opts.VersionInfo.Arch == "aarch64" {
+		instanceType = types.InstanceTypeT4gXlarge
+	}
 
 	createdInstances, err := s.client.RunInstances(ctx, &ec2.RunInstancesInput{
 		MaxCount:         aws.Int32(1),
 		MinCount:         aws.Int32(1),
 		ImageId:          ami,
-		InstanceType:     types.InstanceTypeT4gXlarge,
+		InstanceType:     instanceType,
 		KeyName:          aws.String(s.keyName),
 		SecurityGroupIds: []string{*aws.String(s.securityGroup)},
 		TagSpecifications: []types.TagSpecification{


### PR DESCRIPTION
Use gp3 storage to reduce costs
Give snapshots a name to make them easier to identify in the ui
Add the ec2-user to the couchbase group so it can access logs/config files
Deploy x86 instances using the correct instance type