### PR TITLE
Set 1 as the default number of root certs

### DIFF
--- a/daemon/restserver.go
+++ b/daemon/restserver.go
@@ -691,10 +691,17 @@ func (d *daemon) HttpSetupClientCertAuth(w http.ResponseWriter, r *http.Request)
 		s = d.dockerService
 	}
 
+	var numRoots int
+	if reqData.NumRoots > 0 {
+		numRoots = reqData.NumRoots
+	} else {
+		numRoots = 1
+	}
+
 	certData, err := s.SetupCertAuth(reqCtx, clusterID, service.SetupClientCertAuthOptions{
 		UserName:  reqData.UserName,
 		UserEmail: reqData.UserEmail,
-		NumRoots:  reqData.NumRoots,
+		NumRoots:  numRoots,
 	})
 	if err != nil {
 		writeJSONError(w, err)


### PR DESCRIPTION
If an older version of the client is used, this value can be 0 resulting in a divide by zero error