### PR TITLE
SDKQE-2517: AWS instances not destroyed sometimes

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -15,8 +15,9 @@ type CertAuthResult struct {
 }
 
 type AllocateClusterOptions struct {
-	Deadline time.Time
-	Nodes    []CreateNodeOptions
+	ClusterID string
+	Deadline  time.Time
+	Nodes     []CreateNodeOptions
 }
 
 type CreateNodeOptions struct {
@@ -42,5 +43,5 @@ type ClusterService interface {
 }
 
 type UnmanagedClusterService interface {
-	AllocateCluster(ctx context.Context, opts AllocateClusterOptions) (string, error)
+	AllocateCluster(ctx context.Context, opts AllocateClusterOptions) error
 }


### PR DESCRIPTION
This can happen if the call to KillCluster fails for some reason. Work around this by storing the cluster id before allocating. Any clusters that couldn't be destroyed will get cleaned up after their timeout using the regular cleanup method.