### PR TITLE
SDKQE-2526: Add new endpoint /setup-cluster-encryption

### DIFF
--- a/daemon/json.go
+++ b/daemon/json.go
@@ -185,6 +185,10 @@ type CreateClusterSetupJSON struct {
 	UseDeveloperPreview bool                 `json:"developer_preview"`
 }
 
+type SetupClusterEncryptionJSON struct {
+	Level string `json:"level"`
+}
+
 type CreateClusterJSON struct {
 	Timeout string                  `json:"timeout"`
 	Nodes   []CreateClusterNodeJSON `json:"nodes"`

--- a/service/cloud/cloudservice.go
+++ b/service/cloud/cloudservice.go
@@ -589,6 +589,13 @@ func (cs *CloudService) AddSampleBucket(ctx context.Context, clusterID string, o
 	return errors.New("unsupported operation")
 }
 
+func (cs *CloudService) SetupClusterEncryption(ctx context.Context, clusterID string, opts service.SetupClusterEncryptionOptions) error {
+	if !cs.enabled {
+		return ErrCloudNotEnabled
+	}
+	return errors.New("unsupported operation")
+}
+
 func (cs *CloudService) ConnString(ctx context.Context, clusterID string, useSSL bool) (string, error) {
 	if !useSSL {
 		return "", errors.New("only SSL supported for cloud")

--- a/service/common/encryption.go
+++ b/service/common/encryption.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"github.com/couchbaselabs/cbdynclusterd/service"
+)
+
+func setupClusterEncryption(nodes []Node, opts service.SetupClusterEncryptionOptions) error {
+	epnode := nodes[0]
+
+	autoFailoverEnabled, err := epnode.IsAutoFailoverEnabled()
+	if err != nil {
+		return err
+	}
+
+	// disable auto failover, you can't enable node to node encryption with it enabled
+	if autoFailoverEnabled {
+		if err = epnode.SetAutoFailover(false); err != nil {
+			return err
+		}
+	}
+
+	// setup external listeners, not too sure what this does but it is required
+	for _, node := range nodes {
+		if err = node.ManageExternalListener(true); err != nil {
+			return err
+		}
+	}
+
+	// change node encryption
+	for _, node := range nodes {
+		if err = node.EnableClusterEncryption(); err != nil {
+			return err
+		}
+	}
+
+	// disable external listener
+	for _, node := range nodes {
+		if err = node.ManageExternalListener(false); err != nil {
+			return err
+		}
+	}
+
+	// change level
+	if opts.Level != "" {
+		version, err := getVersion(&epnode)
+		if err != nil {
+			return err
+		}
+		// Strict encryption level is hidden behind a flag in 6.6.5
+		if opts.Level == "strict" && version.Major == 6 {
+			if err := epnode.AllowStrictEncryption(); err != nil {
+				return err
+			}
+		}
+		if err := epnode.SetClusterEncryptionLevel(opts.Level); err != nil {
+			return err
+		}
+	}
+
+	// enable auto failover again if it was originally enabled
+	if autoFailoverEnabled {
+		if err = epnode.SetAutoFailover(true); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/service/docker/dockerservice.go
+++ b/service/docker/dockerservice.go
@@ -248,6 +248,10 @@ func (ds *DockerService) SetupCertAuth(ctx context.Context, clusterID string, op
 	return common.SetupCertAuth(ctx, ds, clusterID, opts)
 }
 
+func (s *DockerService) SetupClusterEncryption(ctx context.Context, clusterID string, opts service.SetupClusterEncryptionOptions) error {
+	return common.SetupClusterEncryption(ctx, s, clusterID, opts)
+}
+
 func (ds *DockerService) AddBucket(ctx context.Context, clusterID string, opts service.AddBucketOptions) error {
 	return common.AddBucket(ctx, ds, clusterID, opts)
 }

--- a/service/ec2/ec2service.go
+++ b/service/ec2/ec2service.go
@@ -408,6 +408,10 @@ func (s *EC2Service) SetupCertAuth(ctx context.Context, clusterID string, opts s
 	return nil, errors.New("not supported yet, requires SSH access")
 }
 
+func (s *EC2Service) SetupClusterEncryption(ctx context.Context, clusterID string, opts service.SetupClusterEncryptionOptions) error {
+	return common.SetupClusterEncryption(ctx, s, clusterID, opts)
+}
+
 func (s *EC2Service) AddBucket(ctx context.Context, clusterID string, opts service.AddBucketOptions) error {
 	return common.AddBucket(ctx, s, clusterID, opts)
 }

--- a/service/options.go
+++ b/service/options.go
@@ -5,6 +5,7 @@ type AddCollectionOptions struct {
 	ScopeName   string
 	BucketName  string
 	UseHostname bool
+	UseSecure   bool
 }
 
 type SetupClientCertAuthOptions struct {
@@ -22,9 +23,16 @@ type AddBucketOptions struct {
 	BucketType     string
 	EvictionPolicy string
 	StorageBackend string
+	UseSecure      bool
 }
 
 type AddSampleOptions struct {
 	SampleBucket string
 	UseHostname  bool
+	UseSecure    bool
+}
+
+type SetupClusterEncryptionOptions struct {
+	Level     string
+	UseSecure bool
 }

--- a/service/service.go
+++ b/service/service.go
@@ -40,6 +40,7 @@ type ClusterService interface {
 	AddIP(ctx context.Context, clusterID, ip string) error
 	AddUser(ctx context.Context, clusterID string, user *helper.UserOption, bucket string) error
 	ConnString(ctx context.Context, clusterID string, useSSL bool) (string, error)
+	SetupClusterEncryption(ctx context.Context, clusterID string, opts SetupClusterEncryptionOptions) error
 }
 
 type UnmanagedClusterService interface {

--- a/store/metadatastore.go
+++ b/store/metadatastore.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/dgraph-io/badger"
 	"github.com/golang/glog"
-	"time"
 )
 
 type ClusterPlatform string
@@ -31,6 +32,7 @@ type ClusterMetaJSON struct {
 	Timeout        string `json:"timeout,omitempty"`
 	Platform       string `json:"platform,omitempty"`
 	CloudClusterID string `json:"cloudClusterID,omitempty"`
+	UseSecure      bool   `json:"useSecure,omitempty"`
 }
 
 type ClusterMeta struct {
@@ -38,6 +40,7 @@ type ClusterMeta struct {
 	Timeout        time.Time
 	Platform       ClusterPlatform
 	CloudClusterID string
+	UseSecure      bool
 }
 
 type MetaDataStore struct {
@@ -64,6 +67,7 @@ func (store *MetaDataStore) serializeMeta(meta ClusterMeta) ([]byte, error) {
 		Timeout:        meta.Timeout.Format(time.RFC3339),
 		Platform:       string(meta.Platform),
 		CloudClusterID: meta.CloudClusterID,
+		UseSecure:      meta.UseSecure,
 	}
 
 	metaBytes, err := json.Marshal(metaJSON)
@@ -91,6 +95,7 @@ func (store *MetaDataStore) deserializeMeta(bytes []byte) (ClusterMeta, error) {
 		Timeout:        parsedTimeout,
 		Platform:       ClusterPlatform(metaJSON.Platform),
 		CloudClusterID: metaJSON.CloudClusterID,
+		UseSecure:      metaJSON.UseSecure,
 	}, nil
 }
 


### PR DESCRIPTION
This endpoint enables node to node encryption. You can pass a level (control or strict)

When strict mode is enabled we store a use secure flag in the cluster metadata so we know to use https for any rest API calls. We skip tls verification because we don't really care about testing this in cbdynclusterd itself.


