### PR TITLE
Always use hostnames when setting up ec2 clusters.

### DIFF
--- a/daemon/restserver.go
+++ b/daemon/restserver.go
@@ -286,7 +286,7 @@ func (d *daemon) HttpSetupCluster(w http.ResponseWriter, r *http.Request) {
 	epnode, err := common.SetupCluster(common.ClusterSetupOptions{
 		Nodes:               c.Nodes,
 		Services:            reqData.Services,
-		UseHostname:         reqData.UseHostname,
+		UseHostname:         reqData.UseHostname || meta.Platform == store.ClusterPlatformEC2,
 		UseIpv6:             reqData.UseIpv6,
 		MemoryQuota:         strconv.Itoa(reqData.RamQuota),
 		User:                reqData.User,


### PR DESCRIPTION
You won't be able to connect if you don't pass the option so set it to true