### PR TITLE
SDKQE-2593: Limit number of containers

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/couchbaselabs/cbdynclusterd/cluster"
@@ -46,3 +47,5 @@ type ClusterService interface {
 type UnmanagedClusterService interface {
 	AllocateCluster(ctx context.Context, opts AllocateClusterOptions) error
 }
+
+var MaxCapacityError = errors.New("max capacity reached")


### PR DESCRIPTION
Keep track of clusters we have allocated to limit it to a configurable max number.

Adds a new parameter docker-max-containers.
Before allocating we check the number of active containers + the number in the process of being allocated to prevent overprovisioning. If we can't allocate the required number we return a custom error. The outer logic then checks for this error and retries until we get a different error or the allocation succeeds. We also update the timeout for the cluster every time we retry so e.g. if it takes 30 minutes to allocate we add 30 minutes to the original timeout
