### PR TITLE
SDKQE-2593: Use system user when fetching all clusters for reservation

### DIFF
--- a/service/docker/dockerservice.go
+++ b/service/docker/dockerservice.go
@@ -48,7 +48,7 @@ func (ds *DockerService) clearReservation(clusterID string) {
 	delete(ds.reserved, clusterID)
 }
 
-func (ds *DockerService) reserve(ctx context.Context, clusterID string, count int) error {
+func (ds *DockerService) reserve(clusterID string, count int) error {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 
@@ -57,7 +57,8 @@ func (ds *DockerService) reserve(ctx context.Context, clusterID string, count in
 		return nil
 	}
 
-	clusters, err := ds.GetAllClusters(ctx)
+	systemCtx := dyncontext.NewContext(context.Background(), "system", true)
+	clusters, err := ds.GetAllClusters(systemCtx)
 	if err != nil {
 		return err
 	}
@@ -214,7 +215,7 @@ func (ds *DockerService) AllocateCluster(ctx context.Context, opts service.Alloc
 		}
 	}
 
-	err = ds.reserve(ctx, opts.ClusterID, len(nodesToAllocate))
+	err = ds.reserve(opts.ClusterID, len(nodesToAllocate))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We need to use the system user to get clusters owned by all users not just the user making the request