### PR TITLE
SDKQE-2592: Set default fts memory quota to 512mb

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -84,6 +84,8 @@ const (
 	AliasRepo     = "https://github.com/couchbaselabs/cb-alias.git"
 	AliasRepoPath = "/opt/cbdynclusterd/alias"
 	AliasFileName = "products.yml"
+
+	FtsDefaultMemoryQuota = 512
 )
 
 type UserOption struct {

--- a/service/common/node.go
+++ b/service/common/node.go
@@ -234,7 +234,7 @@ func (n *Node) AllowStrictEncryption() error {
 }
 
 func (n *Node) SetMemoryQuota(quota string) error {
-	body := fmt.Sprintf("memoryQuota=%s", quota)
+	body := fmt.Sprintf("memoryQuota=%s&ftsMemoryQuota=%d", quota, helper.FtsDefaultMemoryQuota)
 
 	restParam := &helper.RestCall{
 		ExpectedCode: 200,


### PR DESCRIPTION
With 256mb, fts runs out of memory and heavily throttles itself causing test failures