### PR TITLE
SDKQE-2615: Set lower min magma mem quota to allow existing tests to pass

### DIFF
--- a/service/common/manager.go
+++ b/service/common/manager.go
@@ -235,6 +235,13 @@ func (m *Manager) setupNewCluster() (string, error) {
 		return "", err
 	}
 
+	// set minimum magma memory quota for >= neo
+	if version.Major > 7 || version.Major == 7 && version.Minor >= 1 {
+		if err := epnode.SetLowMagmaMinMemoryQuote(); err != nil {
+			return "", err
+		}
+	}
+
 	if version.Major >= 5 && len(m.Config.User.Name) > 0 {
 		glog.Info("CreateUser")
 		if err := epnode.CreateUser(m.Config.User); err != nil {

--- a/service/common/node.go
+++ b/service/common/node.go
@@ -218,6 +218,22 @@ func (n *Node) SetClusterEncryptionLevel(level string) error {
 	return err
 }
 
+// Set the minimum magma bucket size to 256MB as this is what tests expect
+func (n *Node) SetLowMagmaMinMemoryQuote() error {
+	body := "magmaMinMemoryQuota=256"
+
+	restParam := &helper.RestCall{
+		ExpectedCode: 200,
+		Method:       "POST",
+		Path:         helper.PInternalSettings,
+		Cred:         n.RestLogin,
+		Body:         body,
+		Header:       map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+	}
+	_, err := helper.RestRetryer(helper.RestRetry, restParam, helper.GetResponse)
+	return err
+}
+
 func (n *Node) AllowStrictEncryption() error {
 	body := fmt.Sprintf("canEnableStrictEncryption=true")
 


### PR DESCRIPTION
The minimum was recently increased to 1GB but this can be changed with an internal settings call