### PR TITLE
SDKQE-2676: Support per cluster environment settings

### DIFF
--- a/daemon/json.go
+++ b/daemon/json.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/couchbaselabs/cbdynclusterd/cluster"
 	"github.com/couchbaselabs/cbdynclusterd/helper"
+	"github.com/couchbaselabs/cbdynclusterd/store"
 )
 
 func jsonifyCluster(cluster *cluster.Cluster) ClusterJSON {
@@ -252,8 +253,12 @@ type BuildImageResponseJSON struct {
 }
 
 type CreateCloudClusterJSON struct {
-	Timeout  string   `json:"timeout"`
-	Services []string `json:"services"`
+	Timeout     string                  `json:"timeout"`
+	Services    []string                `json:"services"`
+	Environment *store.CloudEnvironment `json:"environment,omitempty"`
+	Region      string                  `json:"region"`
+	Provider    string                  `json:"provider"`
+	SingleAZ    *bool                   `json:"single_az,omitempty"`
 }
 
 type AddIPJSON struct {

--- a/daemon/restserver.go
+++ b/daemon/restserver.go
@@ -949,7 +949,11 @@ func (d *daemon) HttpCreateCloudCluster(w http.ResponseWriter, r *http.Request) 
 
 	clusterID := helper.NewRandomClusterID()
 	clusterOpts := cloud.ClusterSetupOptions{
-		Nodes: nodes,
+		Nodes:       nodes,
+		Environment: reqData.Environment,
+		Region:      reqData.Region,
+		Provider:    reqData.Provider,
+		SingleAZ:    reqData.SingleAZ,
 	}
 
 	cloudClusterID, err := d.cloudService.SetupCluster(reqCtx, clusterID, clusterOpts, helper.RestTimeout)
@@ -962,11 +966,12 @@ func (d *daemon) HttpCreateCloudCluster(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 
 	meta := store.ClusterMeta{
-		Owner:          dyncontext.ContextUser(reqCtx),
-		Timeout:        time.Now().Add(timeout),
-		Platform:       store.ClusterPlatformCloud,
-		CloudClusterID: cloudClusterID,
-		UseSecure:      true,
+		Owner:            dyncontext.ContextUser(reqCtx),
+		Timeout:          time.Now().Add(timeout),
+		Platform:         store.ClusterPlatformCloud,
+		CloudClusterID:   cloudClusterID,
+		UseSecure:        true,
+		CloudEnvironment: reqData.Environment,
 	}
 	if err := d.metaStore.CreateClusterMeta(clusterID, meta); err != nil {
 		writeJSONError(w, err)

--- a/service/cloud/json.go
+++ b/service/cloud/json.go
@@ -38,20 +38,28 @@ type nodeJson struct {
 type V3StorageType string
 
 const (
-	V3StorageTypeGP3 V3StorageType = "GP3"
-	V3StorageTypeIO2 V3StorageType = "IO2"
+	V3StorageTypeGP3    V3StorageType = "GP3"
+	V3StorageTypeIO2    V3StorageType = "IO2"
+	V3StorageTypePD_SSD V3StorageType = "PD-SSD"
 )
-
-var defaultCompute = "m5.xlarge"
-var defaultRegion = "us-west-2"
 
 type V3ServersStorage struct {
 	Type V3StorageType `json:"type"`
-	IOPS uint32        `json:"IOPS"`
+	IOPS uint32        `json:"IOPS,omitempty"`
 	Size uint32        `json:"size"`
 }
 
-var defaultStorage = V3ServersStorage{
+var defaultComputeAWS = "m5.xlarge"
+var defaultRegionAWS = "us-east-2"
+var defaultProvider = V3ProviderAWS
+var defaultSingleAZ = true
+var defaultComputeGCP = "n2-standard-4"
+var defaultRegionGCP = "us-east1"
+var defaultStorageGCP = V3ServersStorage{
+	Type: V3StorageTypePD_SSD,
+	Size: 50,
+}
+var defaultStorageAWS = V3ServersStorage{
 	Type: V3StorageTypeGP3,
 	IOPS: 3000,
 	Size: 50,

--- a/service/cloud/options.go
+++ b/service/cloud/options.go
@@ -2,6 +2,8 @@ package cloud
 
 import (
 	"errors"
+
+	"github.com/couchbaselabs/cbdynclusterd/store"
 )
 
 type NodeSetupOptions struct {
@@ -10,7 +12,11 @@ type NodeSetupOptions struct {
 }
 
 type ClusterSetupOptions struct {
-	Nodes []NodeSetupOptions
+	Nodes       []NodeSetupOptions
+	Environment *store.CloudEnvironment
+	Region      string
+	Provider    string
+	SingleAZ    *bool
 }
 
 func ParseServiceName(service string) (V3CouchbaseService, error) {

--- a/store/metadatastore.go
+++ b/store/metadatastore.go
@@ -27,22 +27,42 @@ var (
 	}
 )
 
+type CloudEnvironment struct {
+	TenantID  string `json:"tenant_id"`
+	ProjectID string `json:"project_id"`
+	URL       string `json:"url"`
+	AccessKey string `json:"access_key"`
+	SecretKey string `json:"secret_key"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+}
+
+func (env CloudEnvironment) BaseURLPublic() string {
+	return fmt.Sprintf("https://cloudapi.%s", env.URL)
+}
+
+func (env CloudEnvironment) BaseURLInternal() string {
+	return fmt.Sprintf("https://api.%s", env.URL)
+}
+
 type ClusterMetaJSON struct {
-	Owner          string `json:"owner,omitempty"`
-	Timeout        string `json:"timeout,omitempty"`
-	Platform       string `json:"platform,omitempty"`
-	CloudClusterID string `json:"cloudClusterID,omitempty"`
-	UseSecure      bool   `json:"useSecure,omitempty"`
-	OS             string `json:"os,omitempty"`
+	Owner            string            `json:"owner,omitempty"`
+	Timeout          string            `json:"timeout,omitempty"`
+	Platform         string            `json:"platform,omitempty"`
+	CloudClusterID   string            `json:"cloudClusterID,omitempty"`
+	UseSecure        bool              `json:"useSecure,omitempty"`
+	OS               string            `json:"os,omitempty"`
+	CloudEnvironment *CloudEnvironment `json:"cloudEnvironment,omitempty"`
 }
 
 type ClusterMeta struct {
-	Owner          string
-	Timeout        time.Time
-	Platform       ClusterPlatform
-	CloudClusterID string
-	UseSecure      bool
-	OS             string
+	Owner            string
+	Timeout          time.Time
+	Platform         ClusterPlatform
+	CloudClusterID   string
+	UseSecure        bool
+	OS               string
+	CloudEnvironment *CloudEnvironment
 }
 
 type MetaDataStore struct {
@@ -65,12 +85,13 @@ func (store *ReadOnlyMetaDataStore) GetClusterMeta(clusterID string) (ClusterMet
 
 func (store *MetaDataStore) serializeMeta(meta ClusterMeta) ([]byte, error) {
 	metaJSON := ClusterMetaJSON{
-		Owner:          meta.Owner,
-		Timeout:        meta.Timeout.Format(time.RFC3339),
-		Platform:       string(meta.Platform),
-		CloudClusterID: meta.CloudClusterID,
-		UseSecure:      meta.UseSecure,
-		OS:             meta.OS,
+		Owner:            meta.Owner,
+		Timeout:          meta.Timeout.Format(time.RFC3339),
+		Platform:         string(meta.Platform),
+		CloudClusterID:   meta.CloudClusterID,
+		UseSecure:        meta.UseSecure,
+		OS:               meta.OS,
+		CloudEnvironment: meta.CloudEnvironment,
 	}
 
 	metaBytes, err := json.Marshal(metaJSON)
@@ -94,12 +115,13 @@ func (store *MetaDataStore) deserializeMeta(bytes []byte) (ClusterMeta, error) {
 	}
 
 	return ClusterMeta{
-		Owner:          metaJSON.Owner,
-		Timeout:        parsedTimeout,
-		Platform:       ClusterPlatform(metaJSON.Platform),
-		CloudClusterID: metaJSON.CloudClusterID,
-		UseSecure:      metaJSON.UseSecure,
-		OS:             metaJSON.OS,
+		Owner:            metaJSON.Owner,
+		Timeout:          parsedTimeout,
+		Platform:         ClusterPlatform(metaJSON.Platform),
+		CloudClusterID:   metaJSON.CloudClusterID,
+		UseSecure:        metaJSON.UseSecure,
+		OS:               metaJSON.OS,
+		CloudEnvironment: metaJSON.CloudEnvironment,
 	}, nil
 }
 


### PR DESCRIPTION
Builds on top of https://github.com/couchbaselabs/cbdynclusterd/pull/71

* Create cloud requests can supply an environment containing all the details needed to create cluster. If one is not supplied the defaults provided by the server side config file are used
* Support GCP clusters
* Support providing custom region, provider and singleAZ

Note: Clusters with custom environments will not show up in the ps command and will not be auto deleted