### PR TITLE
Capella fixes

### DIFF
--- a/service/cloud/cloudservice.go
+++ b/service/cloud/cloudservice.go
@@ -510,11 +510,17 @@ func (cs *CloudService) SetupCluster(ctx context.Context, clusterID string, opts
 		Password: helper.RestPassCapella,
 	}
 	if err := cs.addUser(ctx, clusterID, cloudClusterID, defaultUser); err != nil {
+		go func() {
+			cs.killCluster(ctx, clusterID, cloudClusterID)
+		}()
 		return "", err
 	}
 
 	for _, ip := range cidrAllowlist {
 		if err := cs.addIP(ctx, clusterID, cloudClusterID, ip); err != nil {
+			go func() {
+				cs.killCluster(ctx, clusterID, cloudClusterID)
+			}()
 			return "", err
 		}
 	}

--- a/service/cloud/cloudservice.go
+++ b/service/cloud/cloudservice.go
@@ -113,6 +113,12 @@ func (cs *CloudService) addIP(ctx context.Context, clusterID, cloudClusterID, ip
 		if err != nil {
 			return fmt.Errorf("add ip failed: reason could not be determined: %v", err)
 		}
+		errorBody := string(bb)
+		// AV-35851: Cluster randomly goes into deploying state after adding IP
+		if strings.Contains(errorBody, "ErrClusterStateNotNormal") {
+			time.Sleep(time.Second * 5)
+			return cs.addIP(ctx, clusterID, cloudClusterID, ip)
+		}
 		return fmt.Errorf("add ip failed: %s", string(bb))
 	}
 


### PR DESCRIPTION
- Kill cluster if add ip or user fails
- Retry add ip if AV-35851 occurs