### PR TITLE
SDKQE-2683: Support custom server image for capella

### DIFF
--- a/daemon/restserver.go
+++ b/daemon/restserver.go
@@ -931,16 +931,7 @@ func (d *daemon) HttpCreateCloudCluster(w http.ResponseWriter, r *http.Request) 
 
 	var nodes []cloud.NodeSetupOptions
 	for k, s := range services {
-		servicesStr := strings.Split(k, ",")
-		services := []cloud.V3CouchbaseService{}
-		for _, serviceStr := range servicesStr {
-			service, err := cloud.ParseServiceName(serviceStr)
-			if err != nil {
-				writeJSONError(w, err)
-				return
-			}
-			services = append(services, service)
-		}
+		services := strings.Split(k, ",")
 		nodes = append(nodes, cloud.NodeSetupOptions{
 			Services: services,
 			Size:     s,

--- a/go.mod
+++ b/go.mod
@@ -30,5 +30,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	golang.org/x/crypto v0.0.0-20200403201458-baeed622b8d8
+	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,9 @@ golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/service/cloud/cloudservice.go
+++ b/service/cloud/cloudservice.go
@@ -92,6 +92,11 @@ func (cs *CloudService) addBucket(ctx context.Context, clusterID, cloudClusterID
 		if err != nil {
 			return fmt.Errorf("create bucket failed: reason could not be determined: %v", err)
 		}
+		errorBody := string(bb)
+		// AV-35851: Cluster randomly goes into deploying state after adding IP
+		if strings.Contains(errorBody, "ErrClusterStateNotNormal") {
+			return cs.addBucket(ctx, clusterID, cloudClusterID, opts, env)
+		}
 		return fmt.Errorf("create bucket failed: %s", string(bb))
 	}
 

--- a/service/cloud/constants.go
+++ b/service/cloud/constants.go
@@ -2,7 +2,6 @@ package cloud
 
 const (
 	// public API
-	createClusterPath  = "/v3/clusters"
 	deleteClusterPath  = "/v3/clusters/"
 	getClusterPath     = "/v3/clusters/"
 	getAllClustersPath = "/v3/clusters"
@@ -11,7 +10,9 @@ const (
 	clustersHealthPath = "/v3/clusters/%s/health"
 
 	// internal API
-	internalBasePath    = "/v2/organizations/%s/projects/%s/clusters/%s"
+	internalBasePath = "/v2/organizations/%s/projects/%s/clusters/%s"
+	// Need to use /deploy to use custom image
+	createClusterPath   = "/v2/organizations/%s/clusters/deploy"
 	createBucketPath    = internalBasePath + "/buckets"
 	addIPPath           = internalBasePath + "/allowlists-bulk"
 	addSampleBucketPath = internalBasePath + "/buckets/samples"

--- a/service/cloud/json.go
+++ b/service/cloud/json.go
@@ -35,81 +35,61 @@ type nodeJson struct {
 	AWS      awsServerJSON `json:"aws"`
 }
 
-type V3StorageType string
+type DiskType string
 
 const (
-	V3StorageTypeGP3    V3StorageType = "GP3"
-	V3StorageTypeIO2    V3StorageType = "IO2"
-	V3StorageTypePD_SSD V3StorageType = "PD-SSD"
+	DiskTypeGP3   DiskType = "gp3"
+	DiskTypeIO2   DiskType = "io2"
+	DiskTypePDSSD DiskType = "pd-ssd"
 )
 
-type V3ServersStorage struct {
-	Type V3StorageType `json:"type"`
-	IOPS uint32        `json:"IOPS,omitempty"`
-	Size uint32        `json:"size"`
-}
-
-var defaultComputeAWS = "m5.xlarge"
 var defaultRegionAWS = "us-east-2"
-var defaultProvider = V3ProviderAWS
-var defaultSingleAZ = true
-var defaultComputeGCP = "n2-standard-4"
-var defaultRegionGCP = "us-east1"
-var defaultStorageGCP = V3ServersStorage{
-	Type: V3StorageTypePD_SSD,
-	Size: 50,
+var defaultComputeAWS = Instance{
+	Type: "m5.xlarge",
 }
-var defaultStorageAWS = V3ServersStorage{
-	Type: V3StorageTypeGP3,
-	IOPS: 3000,
-	Size: 50,
+var defaultProvider = ProviderHostedAWS
+var defaultSingleAZ = true
+var defaultComputeGCP = Instance{
+	Type: "n2-standard-4",
+}
+var defaultRegionGCP = "us-east1"
+var defaultDiskeGCP = Disk{
+	Type:     DiskTypePDSSD,
+	SizeInGb: 50,
+}
+var defaultAWSIOPS = 3000
+var defaultDiskAWS = Disk{
+	Type:     DiskTypeGP3,
+	IOPS:     &defaultAWSIOPS,
+	SizeInGb: 50,
 }
 
-type V3CouchbaseService string
+type SupportPackage string
 
 const (
-	V3CouchbaseServiceData      V3CouchbaseService = "data"
-	V3CouchbaseServiceIndex     V3CouchbaseService = "index"
-	V3CouchbaseServiceQuery     V3CouchbaseService = "query"
-	V3CouchbaseServiceSearch    V3CouchbaseService = "search"
-	V3CouchbaseServiceEventing  V3CouchbaseService = "eventing"
-	V3CouchbaseServiceAnalytics V3CouchbaseService = "analytics"
+	SupportPackageDeveloperPro SupportPackage = "developerPro"
 )
 
-type V3Server struct {
-	Size     uint32               `json:"size"`
-	Compute  string               `json:"compute"`
-	Services []V3CouchbaseService `json:"services"`
-	Storage  V3ServersStorage     `json:"storage"`
-}
-
-type supportPackageJson struct {
-	Type     string `json:"type"`
-	Timezone string `json:"timezone"`
-}
-
-var defaultSupportPackage = supportPackageJson{
-	Type:     "DeveloperPro",
-	Timezone: "PT",
-}
+var defaultSupportPackage = SupportPackageDeveloperPro
+var defaultSupportTimezone = ""
 
 var defaultAWS = awsServerJSON{
 	InstanceSize: "m5.xlarge",
 	EbsSizeGib:   50,
 }
 
-type V3Provider string
+type Provider string
 
 const (
-	V3ProviderAWS   V3Provider = "aws"
-	V3ProviderAzure V3Provider = "azure"
-	V3ProviderGCP   V3Provider = "gcp"
+	ProviderHostedAWS Provider = "hostedAWS"
+	ProviderAzure     Provider = "azure"
+	ProviderHostedGCP Provider = "hostedGCP"
 )
 
 type V3PlaceHosted struct {
-	Provider V3Provider `json:"provider"`
-	Region   string     `json:"region"`
-	CIDR     string     `json:"CIDR"`
+	Provider Provider `json:"provider"`
+	Region   string   `json:"region"`
+	CIDR     string   `json:"CIDR"`
 }
 
 type V3Place struct {
@@ -124,13 +104,49 @@ const (
 	V3EnvironmentVPC    V3Environment = "vpc"
 )
 
+type Override struct {
+	Token  string `json:"token"`
+	Image  string `json:"image"`
+	Server string `json:"server"`
+}
+
+type Services []Service
+
+type Service struct {
+	Type string `json:"type"`
+}
+
+type Instance struct {
+	Type       string `json:"type"`
+	CPU        int    `json:"cpu"`
+	MemoryInGb int    `json:"memoryInGb"`
+}
+
+type Disk struct {
+	Type     DiskType `json:"type"`
+	SizeInGb int      `json:"sizeInGb"`
+	IOPS     *int     `json:"iops,omitempty"`
+}
+
+type Spec struct {
+	Count    uint32   `json:"count"`
+	Services Services `json:"services"`
+	Compute  Instance `json:"compute"`
+	Disk     Disk     `json:"disk"`
+}
+
 type setupClusterJson struct {
-	Environment    V3Environment      `json:"environment"`
-	Name           string             `json:"clusterName"`
-	ProjectID      string             `json:"projectId"`
-	Place          V3Place            `json:"place"`
-	Servers        []V3Server         `json:"servers"`
-	SupportPackage supportPackageJson `json:"supportPackage"`
+	CIDR        string         `json:"cidr"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Override    *Override      `json:"overRide,omitempty"`
+	ProjectID   string         `json:"projectId"`
+	Provider    Provider       `json:"provider"`
+	Region      string         `json:"region"`
+	SingleAZ    bool           `json:"singleAZ"`
+	Server      *string        `json:"server"`
+	Specs       []Spec         `json:"specs"`
+	Package     SupportPackage `json:"package"`
 }
 
 type V3BucketRole string

--- a/service/cloud/options.go
+++ b/service/cloud/options.go
@@ -1,13 +1,11 @@
 package cloud
 
 import (
-	"errors"
-
 	"github.com/couchbaselabs/cbdynclusterd/store"
 )
 
 type NodeSetupOptions struct {
-	Services []V3CouchbaseService
+	Services []string
 	Size     uint32
 }
 
@@ -17,23 +15,4 @@ type ClusterSetupOptions struct {
 	Region      string
 	Provider    string
 	SingleAZ    *bool
-}
-
-func ParseServiceName(service string) (V3CouchbaseService, error) {
-	switch service {
-	case "kv":
-		return V3CouchbaseServiceData, nil
-	case "index":
-		return V3CouchbaseServiceIndex, nil
-	case "cbas":
-		return V3CouchbaseServiceAnalytics, nil
-	case "n1ql":
-		return V3CouchbaseServiceQuery, nil
-	case "fts":
-		return V3CouchbaseServiceSearch, nil
-	case "eventing":
-		return V3CouchbaseServiceEventing, nil
-	default:
-		return V3CouchbaseServiceData, errors.New("Unknown service")
-	}
 }

--- a/store/metadatastore.go
+++ b/store/metadatastore.go
@@ -35,6 +35,10 @@ type CloudEnvironment struct {
 	SecretKey string `json:"secret_key"`
 	Username  string `json:"username"`
 	Password  string `json:"password"`
+	// Used when deploying with custom AMI
+	OverrideToken string `json:"override_token"`
+	Image         string `json:"image"`
+	ServerVersion string `json:"server_version"`
 }
 
 func (env CloudEnvironment) BaseURLPublic() string {


### PR DESCRIPTION
This change allows Capella clusters to be created with custom images. For a successful deployment, an override token, server version and image must be supplied. The public API does not allow this functionality so deployment now uses the internal API.

Also, retry on bucket create failure because of AV-35851 which I've seen a few times