### PR TITLE
SDKQE-2724: Download builds using vpn when building AMIs

### DIFF
--- a/packerfiles/aws-yum.pkr.hcl
+++ b/packerfiles/aws-yum.pkr.hcl
@@ -7,25 +7,7 @@ packer {
   }
 }
 
-variable "download_username" {
-  type    = string
-  default = "couchbase"
-}
-
-variable "download_password" {
-  type      = string
-  sensitive = true
-}
-
 variable "build_pkg" {
-  type = string
-}
-
-variable "base_url" {
-  type = string
-}
-
-variable "version" {
   type = string
 }
 
@@ -84,17 +66,16 @@ build {
   sources = [
     "source.amazon-ebs.yum"
   ]
+  provisioner "file" {
+    destination = "/tmp/"
+    source      = "/tmp/${var.build_pkg}"
+  }
   provisioner "shell" {
     inline = [
-      "curl -u ${var.download_username}:${var.download_password} -o ${var.build_pkg} -s ${local.build_url}",
-      "sudo yum install -y ${var.build_pkg}",
-      "rm ${var.build_pkg}",
+      "sudo yum install -y /tmp/${var.build_pkg}",
+      "rm /tmp/${var.build_pkg}",
       "sudo usermod -a -G couchbase ${var.ssh_username}",
       "sudo chmod 770 /opt/couchbase/var/lib/couchbase"
     ]
   }
-}
-
-locals {
-  build_url = "${var.base_url}/${var.build_pkg}"
 }

--- a/service/common/install.go
+++ b/service/common/install.go
@@ -1,8 +1,6 @@
 package common
 
 const (
-	ReleaseUrl         = "http://latestbuilds.service.couchbase.com/builds/releases/"
-	BuildUrl           = "http://latestbuilds.service.couchbase.com/builds/latestbuilds/couchbase-server/"
-	ExternalReleaseUrl = "http://nas.service.couchbase.com/builds/releases/"
-	ExternalBuildUrl   = "http://nas.service.couchbase.com/builds/latestbuilds/couchbase-server/"
+	ReleaseUrl = "http://latestbuilds.service.couchbase.com/builds/releases/"
+	BuildUrl   = "http://latestbuilds.service.couchbase.com/builds/latestbuilds/couchbase-server/"
 )

--- a/service/common/nodes.go
+++ b/service/common/nodes.go
@@ -83,14 +83,6 @@ func (nv *NodeVersion) ToURL() string {
 	return fmt.Sprintf("%s%s/%s", BuildUrl, nv.Flavor, nv.Build)
 }
 
-func (nv *NodeVersion) ToExternalURL() string {
-	// If there's no build number specified then the target is a release
-	if nv.Build == "" {
-		return fmt.Sprintf("%s%s", ExternalReleaseUrl, nv.Version)
-	}
-	return fmt.Sprintf("%s%s/%s", ExternalBuildUrl, nv.Flavor, nv.Build)
-}
-
 var versionToFlavor = map[int]map[int]string{
 	4: {0: "sherlock", 5: "watson"},
 	5: {0: "spock", 5: "vulcan"},

--- a/service/ec2/packer.go
+++ b/service/ec2/packer.go
@@ -7,13 +7,10 @@ import (
 )
 
 type PackerOptions struct {
-	DownloadPassword string
-	Version          string
-	BuildPkg         string
-	BaseUrl          string
-	AmiName          string
-	Arch             string
-	OS               string
+	BuildPkg string
+	AmiName  string
+	Arch     string
+	OS       string
 }
 
 func addArg(args *[]string, arg string) {
@@ -59,10 +56,7 @@ func CallPacker(opts PackerOptions) error {
 	args := []string{}
 
 	args = append(args, "build")
-	addArg(&args, "download_password="+opts.DownloadPassword)
-	addArg(&args, "version="+opts.Version)
 	addArg(&args, "build_pkg="+opts.BuildPkg)
-	addArg(&args, "base_url="+opts.BaseUrl)
 	addArg(&args, "ami_name="+opts.AmiName)
 	addArg(&args, "arch="+opts.Arch)
 	addArg(&args, "source_ami_filter="+packageToAMIArg[opts.OS][opts.Arch].SourceAMIFilter)


### PR DESCRIPTION
Instead of downloading the build from within the packer ec2 instance, download it on the local machine (which is on the vpn) to /tmp and copy it over