### PR TITLE
SDKQE-2730: Support creating cluster in serverless mode

### DIFF
--- a/daemon/json.go
+++ b/daemon/json.go
@@ -174,6 +174,7 @@ type CreateClusterNodeJSON struct {
 	UseCommunityEdition bool   `json:"community_edition"`
 	OS                  string `json:"os"`
 	Arch                string `json:"arch"`
+	ServerlessMode      bool   `json:"serverless_mode"`
 }
 
 type CreateClusterSetupJSON struct {
@@ -246,6 +247,7 @@ type BuildImageJSON struct {
 	UseCommunityEdition bool   `json:"community_edition"`
 	OS                  string `json:"os"`
 	Arch                string `json:"arch"`
+	ServerlessMode      bool   `json:"serverless_mode"`
 }
 
 type BuildImageResponseJSON struct {

--- a/daemon/restserver.go
+++ b/daemon/restserver.go
@@ -119,6 +119,7 @@ func (d *daemon) HttpCreateCluster(w http.ResponseWriter, r *http.Request) {
 			UseCommunityEdition: node.UseCommunityEdition,
 			OS:                  node.OS,
 			Arch:                node.Arch,
+			ServerlessMode:      node.ServerlessMode,
 		}
 		clusterOpts.Nodes = append(clusterOpts.Nodes, nodeOpts)
 		if node.Platform == "ec2" {
@@ -870,7 +871,7 @@ func (d *daemon) HttpBuildImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	image, err := d.dockerService.EnsureImageExists(reqCtx, reqData.ServerVersion, reqData.OS, reqData.Arch, reqData.UseCommunityEdition)
+	image, err := d.dockerService.EnsureImageExists(reqCtx, reqData.ServerVersion, reqData.OS, reqData.Arch, reqData.UseCommunityEdition, reqData.ServerlessMode)
 	if err != nil {
 		writeJSONError(w, err)
 		return

--- a/dockerfiles/couchbase/centos7/Dockerfile
+++ b/dockerfiles/couchbase/centos7/Dockerfile
@@ -22,6 +22,7 @@ ARG BUILD_NO=2412
 ARG FLAVOR=spock
 ARG BUILD_PKG=couchbase-server-enterprise-$VERSION-$BUILD_NO-centos7.x86_64.rpm
 ARG BASE_URL=http://latestbuilds.service.couchbase.com/builds/latestbuilds/couchbase-server/$FLAVOR/$BUILD_NO
+ARG SERVERLESS_MODE=false
 
 ARG BUILD_URL=$BASE_URL/$BUILD_PKG
 
@@ -30,6 +31,8 @@ RUN wget -q -N $BUILD_URL
 
 # Install couchbase
 RUN rpm --install $BUILD_PKG 
+
+RUN if [ ${SERVERLESS_MODE} == 'true' ]; then mkdir -p /etc/couchbase.d && /bin/sh -c 'echo serverless > /etc/couchbase.d/config_profile' && chmod 755 /etc/couchbase.d/config_profile; fi
 
 #clean the cache
 RUN yum clean all
@@ -47,9 +50,9 @@ LABEL Vendor=Couchbase
 LABEL Version=${VERSION}
 LABEL Architecture="x86_64"
 LABEL RUN="docker run -d --rm --privileged -p 8091:8091 --restart always --name NAME IMAGE \
-            -v /opt/couchbase/var:/opt/couchbase/var \
-            -v /opt/couchbase/var/lib/moxi:/opt/couchbase/var/lib/moxi \
-            -v /opt/couchbase/var/lib/stats:/opt/couchbase/var/lib/stats "
+    -v /opt/couchbase/var:/opt/couchbase/var \
+    -v /opt/couchbase/var/lib/moxi:/opt/couchbase/var/lib/moxi \
+    -v /opt/couchbase/var/lib/stats:/opt/couchbase/var/lib/stats "
 
 
 ENV PATH=$PATH:/opt/couchbase/bin:/opt/couchbase/bin/tools:/opt/couchbase/bin/install

--- a/packerfiles/aws-yum.pkr.hcl
+++ b/packerfiles/aws-yum.pkr.hcl
@@ -36,6 +36,11 @@ variable "device_name" {
   type = string
 }
 
+variable "serverless_mode" {
+  type = bool
+  default = false
+}
+
 source "amazon-ebs" "yum" {
   ami_name      = var.ami_name
   instance_type = var.arch == "aarch64" ? "t4g.micro" : "t2.micro"
@@ -75,7 +80,8 @@ build {
       "sudo yum install -y /tmp/${var.build_pkg}",
       "rm /tmp/${var.build_pkg}",
       "sudo usermod -a -G couchbase ${var.ssh_username}",
-      "sudo chmod 770 /opt/couchbase/var/lib/couchbase"
+      "sudo chmod 770 /opt/couchbase/var/lib/couchbase",
+      "if [ ${var.serverless_mode} == 'true' ]; then sudo mkdir -p /etc/couchbase.d && sudo /bin/sh -c 'echo serverless > /etc/couchbase.d/config_profile' && sudo chmod 755 /etc/couchbase.d/config_profile; fi"
     ]
   }
 }

--- a/service/docker/dockerservice.go
+++ b/service/docker/dockerservice.go
@@ -297,8 +297,8 @@ func (ds *DockerService) KillAllClusters(ctx context.Context) error {
 	return common.KillAllClusters(ctx, ds)
 }
 
-func (ds *DockerService) EnsureImageExists(ctx context.Context, serverVersion, os, arch string, useCommunity bool) (string, error) {
-	nodeVersion, err := common.ParseServerVersion(serverVersion, os, arch, useCommunity)
+func (ds *DockerService) EnsureImageExists(ctx context.Context, serverVersion, os, arch string, useCommunity, serverlessMode bool) (string, error) {
+	nodeVersion, err := common.ParseServerVersion(serverVersion, os, arch, useCommunity, serverlessMode)
 	if err != nil {
 		return "", err
 	}

--- a/service/docker/images.go
+++ b/service/docker/images.go
@@ -73,6 +73,10 @@ func (ds *DockerService) imageBuild(ctx context.Context, nodeVersion *common.Nod
 	buildArgs["FLAVOR"] = &nodeVersion.Flavor
 	buildArgs["BUILD_PKG"] = &pkg
 	buildArgs["BASE_URL"] = &url
+	if nodeVersion.ServerlessMode {
+		serverlessMode := "true"
+		buildArgs["SERVERLESS_MODE"] = &serverlessMode
+	}
 
 	buildCtx, err := os.Open(tarPath)
 	defer buildCtx.Close()

--- a/service/ec2/packer.go
+++ b/service/ec2/packer.go
@@ -7,10 +7,11 @@ import (
 )
 
 type PackerOptions struct {
-	BuildPkg string
-	AmiName  string
-	Arch     string
-	OS       string
+	BuildPkg       string
+	AmiName        string
+	Arch           string
+	OS             string
+	ServerlessMode bool
 }
 
 func addArg(args *[]string, arg string) {
@@ -63,6 +64,7 @@ func CallPacker(opts PackerOptions) error {
 	addArg(&args, "ssh_username="+osToSSHUsername[opts.OS])
 	addArg(&args, "ami_owner="+packageToAMIArg[opts.OS][opts.Arch].Owner)
 	addArg(&args, "device_name="+osToDeviceName[opts.OS])
+	addArg(&args, "serverless_mode="+fmt.Sprintf("%t", opts.ServerlessMode))
 	args = append(args, filePath)
 
 	cmd := exec.Command("packer", args...)

--- a/service/service.go
+++ b/service/service.go
@@ -27,6 +27,7 @@ type CreateNodeOptions struct {
 	UseCommunityEdition bool
 	OS                  string
 	Arch                string
+	ServerlessMode      bool
 }
 
 type ConnectContext struct {


### PR DESCRIPTION
Validated by creating a bucket, defaults to 64 vbuckets

{"name":"default","nodeLocator":"vbucket","bucketType":"membase","storageBackend":"couchstore","uuid":"85b69d02fd0b5fa0649689faf48a1814","uri":"/pools/default/buckets/default?bucket_uuid=85b69d02fd0b5fa0649689faf48a1814","streamingUri":"/pools/default/bucketsStreaming/default?bucket_uuid=85b69d02fd0b5fa0649689faf48a1814","numVBuckets":64,"bucketCapabilitiesVer":"","bucketCapabilities":["collections","durableWrite","tombstonedUserXAttrs","couchapi","subdoc.ReplaceBodyWithXattr","subdoc.DocumentMacroSupport","subdoc.ReviveDocument","preserveExpiry","rangeScan","dcp","cbhello","touch","cccp","xdcrCheckpointing","nodesExt","xattr"],"collectionsManifestUid":"1","ddocs":{"uri":"/pools/default/buckets/default/ddocs"},"vBucketServerMap":{"hashAlgorithm":"CRC","numReplicas":1,"serverList":["172.23.111.131:11210"],"vBucketMap":[[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1],[0,-1]]},"localRandomKeyUri":"/pools/default/buckets/default/localRandomKey","controllers":{"compactAll":"/pools/default/buckets/default/controller/compactBucket","compactDB":"/pools/default/buckets/default/controller/compactDatabases","purgeDeletes":"/pools/default/buckets/default/controller/unsafePurgeBucket","startRecovery":"/pools/default/buckets/default/controller/startRecovery"},"nodes":[{"couchApiBaseHTTPS":"https://172.23.111.131:18092/default%2B85b69d02fd0b5fa0649689faf48a1814","couchApiBase":"http://172.23.111.131:8092/default%2B85b69d02fd0b5fa0649689faf48a1814","clusterMembership":"active","recoveryType":"none","status":"healthy","otpNode":"ns_1@cb.local","thisNode":true,"hostname":"172.23.111.131:8091","nodeUUID":"6d6b9a2ce28f726e99b5519b77bc4989","clusterCompatibility":458754,"version":"7.2.0-1614-enterprise","os":"x86_64-pc-linux-gnu","cpuCount":24,"ports":{"direct":11210,"httpsCAPI":18092,"httpsMgmt":18091,"distTCP":21100,"distTLS":21150},"services":["kv"],"nodeEncryption":false,"nodeEncryptionClientCertVerification":false,"addressFamilyOnly":false,"configuredHostname":"127.0.0.1:8091","addressFamily":"inet","externalListeners":[{"afamily":"inet","nodeEncryption":false}],"serverGroup":"Group 1","replication":0,"nodeHash":130331213,"systemStats":{"cpu_utilization_rate":0,"cpu_stolen_rate":0.2460442031137318,"swap_total":2046816256,"swap_used":126459904,"mem_total":49093763072,"mem_free":36348489728,"mem_limit":49093763072,"cpu_cores_available":24,"allocstall":24510044},"interestingStats":{"cmd_get":0,"couch_docs_actual_disk_size":530958,"couch_docs_data_size":82321,"couch_spatial_data_size":0,"couch_spatial_disk_size":0,"couch_views_actual_disk_size":0,"couch_views_data_size":0,"curr_items":0,"curr_items_tot":0,"ep_bg_fetched":0,"get_hits":0,"mem_used":5507040,"ops":0,"vb_active_num_non_resident":0,"vb_replica_curr_items":0},"uptime":"69","memoryTotal":49093763072,"memoryFree":36348489728,"mcdMemoryReserved":37455,"mcdMemoryAllocated":37455}],"stats":{"uri":"/pools/default/buckets/default/stats","directoryURI":"/pools/default/buckets/default/stats/Directory","nodeStatsListURI":"/pools/default/buckets/default/nodes"},"authType":"sasl","autoCompactionSettings":false,"replicaIndex":true,"replicaNumber":1,"threadsNumber":3,"quota":{"ram":268435456,"rawRAM":268435456},"basicStats":{"quotaPercentUsed":2.05153226852417,"opsPerSec":0,"diskFetches":0,"itemCount":0,"diskUsed":530958,"dataUsed":82321,"memUsed":5507040,"vbActiveNumNonResident":0},"evictionPolicy":"valueOnly","durabilityMinLevel":"none","pitrEnabled":false,"pitrGranularity":600,"pitrMaxHistoryAge":86400,"conflictResolutionType":"seqno","maxTTL":0,"compressionMode":"passive"}