### PR TITLE
SDKQE-2731: Support width and vbucket count for serverless buckets

### DIFF
--- a/cluster/bucket.go
+++ b/cluster/bucket.go
@@ -7,4 +7,6 @@ type Bucket struct {
 	ReplicaCount      int
 	EphEvictionPolicy string
 	StorageBackend    string
+	NumVBuckets       int
+	Width             int
 }

--- a/daemon/json.go
+++ b/daemon/json.go
@@ -216,6 +216,8 @@ type AddBucketJSON struct {
 	BucketType     string `json:"bucket_type"`
 	EvictionPolicy string `json:"eviction_policy"`
 	StorageBackend string `json:"storage_backend"`
+	Width          int    `json:"width"`
+	NumVBuckets    int    `json:"num_vbuckets"`
 }
 
 type AddSampleBucketJSON struct {

--- a/daemon/restserver.go
+++ b/daemon/restserver.go
@@ -555,6 +555,8 @@ func (d *daemon) HttpAddBucket(w http.ResponseWriter, r *http.Request) {
 		BucketType:     reqData.BucketType,
 		EvictionPolicy: reqData.EvictionPolicy,
 		StorageBackend: reqData.StorageBackend,
+		Width:          reqData.Width,
+		NumVBuckets:    reqData.NumVBuckets,
 	}, service.ConnectContext{UseSecure: meta.UseSecure})
 	if err != nil {
 		writeJSONError(w, err)

--- a/service/common/clusters.go
+++ b/service/common/clusters.go
@@ -130,6 +130,8 @@ func AddBucket(ctx context.Context, s service.ClusterService, clusterID string, 
 		RamQuotaMB:        strconv.Itoa(opts.RamQuota),
 		EphEvictionPolicy: opts.EvictionPolicy,
 		StorageBackend:    opts.StorageBackend,
+		NumVBuckets:       opts.NumVBuckets,
+		Width:             opts.Width,
 	})
 }
 

--- a/service/common/node.go
+++ b/service/common/node.go
@@ -512,6 +512,16 @@ func (n *Node) CreateBucket(conf *cluster.Bucket) error {
 		}
 	}
 
+	if conf.NumVBuckets != 0 {
+		body = fmt.Sprintf("%s&numVBuckets=%d", body, conf.NumVBuckets)
+	}
+
+	if conf.Width != 0 {
+		// set to lowest weight of 1
+		body = fmt.Sprintf("%s&weight=1", body)
+		body = fmt.Sprintf("%s&width=%d", body, conf.Width)
+	}
+
 	restParam := &helper.RestCall{
 		ExpectedCode: 202,
 		Method:       "POST",

--- a/service/options.go
+++ b/service/options.go
@@ -22,6 +22,8 @@ type AddBucketOptions struct {
 	BucketType     string
 	EvictionPolicy string
 	StorageBackend string
+	NumVBuckets    int
+	Width          int
 }
 
 type AddSampleOptions struct {


### PR DESCRIPTION
Verified by creating bucket with num-vbuckets 16 and width 1

```
[
  {
    "name": "default2",
    "nodeLocator": "vbucket",
    "bucketType": "membase",
    "storageBackend": "couchstore",
    "uuid": "51b14f1d29c74ba1272f1f291419031d",
    "uri": "/pools/default/buckets/default2?bucket_uuid=51b14f1d29c74ba1272f1f291419031d",
    "streamingUri": "/pools/default/bucketsStreaming/default2?bucket_uuid=51b14f1d29c74ba1272f1f291419031d",
    "numVBuckets": 16,
    "bucketCapabilitiesVer": "",
    "bucketCapabilities": [
      "collections",
      "durableWrite",
      "tombstonedUserXAttrs",
      "couchapi",
      "subdoc.ReplaceBodyWithXattr",
      "subdoc.DocumentMacroSupport",
      "subdoc.ReviveDocument",
      "preserveExpiry",
      "rangeScan",
      "dcp",
      "cbhello",
      "touch",
      "cccp",
      "xdcrCheckpointing",
      "nodesExt",
      "xattr"
    ],
    "collectionsManifestUid": "1",
    "ddocs": { "uri": "/pools/default/buckets/default2/ddocs" },
    "vBucketServerMap": {
      "hashAlgorithm": "CRC",
      "numReplicas": 1,
      "serverList": ["172.23.111.131:11210"],
      "vBucketMap": [
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1],
        [0, -1]
      ]
    },
    "localRandomKeyUri": "/pools/default/buckets/default2/localRandomKey",
    "controllers": {
      "compactAll": "/pools/default/buckets/default2/controller/compactBucket",
      "compactDB": "/pools/default/buckets/default2/controller/compactDatabases",
      "purgeDeletes": "/pools/default/buckets/default2/controller/unsafePurgeBucket",
      "startRecovery": "/pools/default/buckets/default2/controller/startRecovery"
    },
    "nodes": [
      {
        "couchApiBaseHTTPS": "https://172.23.111.131:18092/default2%2B51b14f1d29c74ba1272f1f291419031d",
        "couchApiBase": "http://172.23.111.131:8092/default2%2B51b14f1d29c74ba1272f1f291419031d",
        "clusterMembership": "active",
        "recoveryType": "none",
        "status": "healthy",
        "otpNode": "ns_1@cb.local",
        "thisNode": true,
        "hostname": "172.23.111.131:8091",
        "nodeUUID": "6d6b9a2ce28f726e99b5519b77bc4989",
        "clusterCompatibility": 458754,
        "version": "7.2.0-1614-enterprise",
        "os": "x86_64-pc-linux-gnu",
        "cpuCount": 24,
        "ports": {
          "direct": 11210,
          "httpsCAPI": 18092,
          "httpsMgmt": 18091,
          "distTCP": 21100,
          "distTLS": 21150
        },
        "services": ["kv"],
        "nodeEncryption": false,
        "nodeEncryptionClientCertVerification": false,
        "addressFamilyOnly": false,
        "configuredHostname": "127.0.0.1:8091",
        "addressFamily": "inet",
        "externalListeners": [{ "afamily": "inet", "nodeEncryption": false }],
        "serverGroup": "Group 1",
        "replication": 0,
        "nodeHash": 130331213,
        "systemStats": {
          "cpu_utilization_rate": 0,
          "cpu_stolen_rate": 0.1345498885758735,
          "swap_total": 2046816256,
          "swap_used": 126459904,
          "mem_total": 49093763072,
          "mem_free": 40844976128,
          "mem_limit": 49093763072,
          "cpu_cores_available": 24,
          "allocstall": 24510044
        },
        "interestingStats": {
          "cmd_get": 0,
          "couch_docs_actual_disk_size": 530958,
          "couch_docs_data_size": 82321,
          "couch_spatial_data_size": 0,
          "couch_spatial_disk_size": 0,
          "couch_views_actual_disk_size": 0,
          "couch_views_data_size": 0,
          "curr_items": 0,
          "curr_items_tot": 0,
          "ep_bg_fetched": 0,
          "get_hits": 0,
          "mem_used": 5507040,
          "ops": 0,
          "vb_active_num_non_resident": 0,
          "vb_replica_curr_items": 0
        },
        "uptime": "3756",
        "memoryTotal": 49093763072,
        "memoryFree": 40844976128,
        "mcdMemoryReserved": 37455,
        "mcdMemoryAllocated": 37455
      }
    ],
    "stats": {
      "uri": "/pools/default/buckets/default2/stats",
      "directoryURI": "/pools/default/buckets/default2/stats/Directory",
      "nodeStatsListURI": "/pools/default/buckets/default2/nodes"
    },
    "authType": "sasl",
    "autoCompactionSettings": false,
    "replicaIndex": true,
    "width": 1,
    "weight": 1,
    "replicaNumber": 1,
    "threadsNumber": 3,
    "quota": { "ram": 209715200, "rawRAM": 209715200 },
    "basicStats": {
      "quotaPercentUsed": 0,
      "opsPerSec": 0,
      "diskFetches": 0,
      "itemCount": 0,
      "diskUsed": 0,
      "dataUsed": 0,
      "memUsed": 0,
      "vbActiveNumNonResident": 0
    },
    "evictionPolicy": "valueOnly",
    "durabilityMinLevel": "none",
    "pitrEnabled": false,
    "pitrGranularity": 600,
    "pitrMaxHistoryAge": 86400,
    "conflictResolutionType": "seqno",
    "maxTTL": 0,
    "compressionMode": "passive"
  }
]
```