### PR TITLE
SDKQE-2748: Load sample bucket should only check item counts in the default collection

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -171,19 +171,29 @@ func RestRetryer(retry int, params *RestCall, fn func(*RestCall) (string, error)
 	return body, nil
 }
 
-func Tuple(version string) (int, int, int) {
+type VersionTuple struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func (v *VersionTuple) String() string {
+	return fmt.Sprintf("%d-%d-%d", v.Major, v.Minor, v.Patch)
+}
+
+func Tuple(version string) VersionTuple {
 	v := strings.Split(version, "-")[0]
 	parsed := strings.Split(v, ".")
 
 	if len(parsed) != 3 {
-		return 0, 0, 0
+		return VersionTuple{Major: 0, Minor: 0, Patch: 0}
 	}
 
 	major, _ := strconv.Atoi(parsed[0])
 	minor, _ := strconv.Atoi(parsed[1])
 	patch, _ := strconv.Atoi(parsed[2])
 
-	return major, minor, patch
+	return VersionTuple{Major: major, Minor: minor, Patch: patch}
 }
 
 func GetResponse(params *RestCall) (string, error) {

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -54,6 +54,7 @@ const (
 	PRebalanceStop           = "/controller/stopRebalance"
 	PPoolsNodes              = "/pools/nodes"
 	PBuckets                 = "/pools/default/buckets"
+	PStats                   = "/pools/default/stats/range"
 	PFailover                = "/controller/failOver"
 	PEject                   = "/controller/ejectNode"
 	PSetupServices           = "/node/controller/setupServices"

--- a/service/cloud/cloudservice.go
+++ b/service/cloud/cloudservice.go
@@ -747,7 +747,7 @@ func (cs *CloudService) addSampleBucket(ctx context.Context, clusterID, cloudClu
 		return err
 	}
 
-	node := common.NewNode(c.Nodes[0].IPv4Address, connCtx)
+	node := common.NewNode(c.Nodes[0].IPv4Address, c.Nodes[0].InitialServerVersion, connCtx)
 
 	if err = node.WaitForBucketHealthy(name); err != nil {
 		return err

--- a/service/common/encryption.go
+++ b/service/common/encryption.go
@@ -42,10 +42,7 @@ func setupClusterEncryption(nodes []Node, opts service.SetupClusterEncryptionOpt
 
 	// change level
 	if opts.Level != "" {
-		version, err := getVersion(&epnode)
-		if err != nil {
-			return err
-		}
+		version := epnode.VersionTuple()
 		// Strict encryption level is hidden behind a flag in 6.6.5
 		if opts.Level == "strict" && version.Major == 6 {
 			if err := epnode.AllowStrictEncryption(); err != nil {


### PR DESCRIPTION
Tested this on 6.6.5, 7.1.1 and 7.2.0-1831 serverless where this was previously timing out