### PR TITLE
SDKQE-2766: Automate platform cert testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@ This is a daemon used to manage the test-cluster system managed by the SDKQE tea
 
 It exposes a REST API and allows you to allocate/deallocate clusters inside
 of the corporate network for the purposes of doing testing.
+
+Regenerating Trusted Certs
+
+The certs can be regenerated using the letsencrpyt certbot and aws route53 credentials
+
+Generate the new certs
+
+docker run -it --rm -v "/etc/letsencrypt:/etc/letsencrypt" -v "/var/lib/letsencrypt:/var/lib/letsencrypt" -e "AWS_ACCESS_KEY_ID=XXX" -e "AWS_SECRET_ACCESS_KEY=XXX" certbot/dns-route53 certonly --dns-route53 -d "*.cbqeoc.com"
+
+Then put the paths to these files in the ~/.cbdynclusterd.toml config file
+
+trusted-root-ca-path: /etc/letsencrypt/live/cbqeoc.com/chain.pem
+trusted-private-key-path: /etc/letsencrypt/live/cbqeoc.com/privkey.pem
+trusted-cert-path: /etc/letsencrypt/live/cbqeoc.com/cert.pem

--- a/cluster/node.go
+++ b/cluster/node.go
@@ -9,4 +9,5 @@ type Node struct {
 	IPv4Address          string
 	IPv6Address          string
 	Version              string
+	Hostname             string
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -239,7 +239,11 @@ func (d *daemon) getAndPrintClusters() {
 	for _, c := range clusters {
 		log.Printf("  %s [Owner: %s, Creator: %s, Timeout: %s]", c.ID, c.Owner, c.Creator, c.Timeout.Sub(time.Now()).Round(time.Second))
 		for _, node := range c.Nodes {
-			log.Printf("    %-16s  %-20s %-10s %-20s", node.ContainerID, node.Name, node.InitialServerVersion, node.IPv4Address)
+			hostname := node.IPv4Address
+			if node.Hostname != "" {
+				hostname = node.Hostname
+			}
+			log.Printf("    %-16s  %-20s %-10s %-20s", node.ContainerID, node.Name, node.InitialServerVersion, hostname)
 		}
 	}
 }

--- a/daemon/json.go
+++ b/daemon/json.go
@@ -70,13 +70,18 @@ func jsonifyError(err error) ErrorJSON {
 }
 
 func jsonifyNode(node *cluster.Node) NodeJSON {
+	hostname := node.IPv4Address
+	if node.Hostname != "" {
+		hostname = node.Hostname
+	}
+
 	return NodeJSON{
 		ID:                   node.ContainerID,
 		ContainerName:        node.ContainerName,
 		State:                node.State,
 		Name:                 node.Name,
 		InitialServerVersion: node.InitialServerVersion,
-		IPv4Address:          node.IPv4Address,
+		IPv4Address:          hostname,
 		IPv6Address:          node.IPv6Address,
 	}
 }

--- a/service/common/certauth.go
+++ b/service/common/certauth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/couchbaselabs/cbdynclusterd/service"
 )
 
-func setupCertAuth(username, email string, nodes []Node, clusterVersion string, numRoots int) (*service.CertAuthResult, error) {
+func setupCertAuth(username, email string, nodes []Node, numRoots int) (*service.CertAuthResult, error) {
 
 	var rootKeys = []*rsa.PrivateKey{}
 	var rootCerts = []*x509.Certificate{}
@@ -37,7 +37,7 @@ func setupCertAuth(username, email string, nodes []Node, clusterVersion string, 
 
 	for i, node := range nodes {
 		var rootIndex = i % len(rootCerts)
-		if err := node.SetupCert(rootCerts, rootKeys, now, clusterVersion, rootIndex); err != nil {
+		if err := node.SetupCert(rootCerts, rootKeys, now, rootIndex); err != nil {
 			return nil, err
 		}
 	}

--- a/service/common/clusters.go
+++ b/service/common/clusters.go
@@ -147,13 +147,12 @@ func SetupCertAuth(ctx context.Context, s service.ClusterService, clusterID stri
 	}
 
 	initialNodes := c.Nodes
-	clusterVersion := initialNodes[0].InitialServerVersion
 	var nodes []Node
 	for _, node := range initialNodes {
 		nodes = append(nodes, *NewNode(node.IPv4Address, node.InitialServerVersion, connCtx))
 	}
 
-	return setupCertAuth(opts.UserName, opts.UserEmail, nodes, clusterVersion, opts.NumRoots)
+	return setupCertAuth(opts.UserName, opts.UserEmail, nodes, opts.NumRoots)
 }
 
 func SetupClusterEncryption(ctx context.Context, s service.ClusterService, clusterID string, opts service.SetupClusterEncryptionOptions, connCtx service.ConnectContext) error {

--- a/service/common/clusters.go
+++ b/service/common/clusters.go
@@ -82,7 +82,11 @@ func ConnString(ctx context.Context, s service.ClusterService, clusterID string,
 
 	var addresses []string
 	for _, node := range c.Nodes {
-		addresses = append(addresses, node.IPv4Address)
+		hostname := node.IPv4Address
+		if node.Hostname != "" {
+			hostname = node.Hostname
+		}
+		addresses = append(addresses, hostname)
 	}
 
 	scheme := "couchbase"

--- a/service/common/node.go
+++ b/service/common/node.go
@@ -1486,3 +1486,25 @@ func (n *Node) RunCBCollect() ([]byte, error) {
 func (n *Node) VersionTuple() helper.VersionTuple {
 	return helper.Tuple(n.Version)
 }
+
+func (n *Node) CreateHostsFile() error {
+	client, err := newClient(n.SshLogin)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	// append to hosts file
+	err = session.Run(fmt.Sprintf("echo '127.0.0.1 %s' | sudo tee -a /etc/hosts", n.HostName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/service/common/nodes.go
+++ b/service/common/nodes.go
@@ -210,7 +210,7 @@ func CreateNodesToAllocate(nodes []service.CreateNodeOptions, aliasRepoPath stri
 			VersionInfo:   nodeVersion,
 		}
 		if nodeToAllocate.Name == "" {
-			nodeToAllocate.Name = fmt.Sprintf("node_%d", nodeIdx+1)
+			nodeToAllocate.Name = fmt.Sprintf("node%d", nodeIdx+1)
 		}
 
 		nodesToAllocate = append(nodesToAllocate, nodeToAllocate)


### PR DESCRIPTION
This PR is split into 2 commits. The first creates custom hostnames for ec2 nodes. This is required because we need to get a signed cert for a domain we own which we can't do for the default AWS hostnames. The second actually sets up the cluster with the certs that are provided in the config. I updated the README to document how to generate these certs because they will need to be regenerated every year after they expire.

The end result

![image](https://user-images.githubusercontent.com/777143/195130942-bf24ab91-48fe-4b23-ac55-6ffec1c2c66b.png)
