### PR TITLE
SDKQE-3565 replace capella v3 api's to v4 api's

### DIFF
--- a/service/cloud/client.go
+++ b/service/cloud/client.go
@@ -3,20 +3,13 @@ package cloud
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/couchbaselabs/cbdynclusterd/store"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strconv"
-	"strings"
 	"sync"
-	"time"
-
-	"github.com/couchbaselabs/cbdynclusterd/store"
 )
 
 // Totally not stolen from https://github.com/couchbasecloud/rest-api-examples/blob/main/go/client/client.go
@@ -69,15 +62,8 @@ func (c *client) Do(ctx context.Context, method, uri string, body interface{}, e
 		return nil, err
 	}
 
-	now := strconv.FormatInt(time.Now().Unix(), 10)
-	r.Header.Add(headerKeyTimestamp, now)
-
-	payload := strings.Join([]string{method, uri, now}, "\n")
-	h := hmac.New(sha256.New, []byte(env.SecretKey))
-	h.Write([]byte(payload))
-
-	bearer := "Bearer " + env.AccessKey + ":" + base64.StdEncoding.EncodeToString(h.Sum(nil))
-	r.Header.Add(headerKeyAuthorization, bearer)
+	bearer := fmt.Sprintf("Bearer %s", env.SecretKey)
+	r.Header.Set(headerKeyAuthorization, bearer)
 
 	return c.httpClient.Do(r)
 }

--- a/service/cloud/cloudservice.go
+++ b/service/cloud/cloudservice.go
@@ -89,7 +89,7 @@ func NewCloudService(defaultEnvKey string, config map[string]CapellaConfig, meta
 }
 
 func (cs *CloudService) getCluster(ctx context.Context, cloudClusterID string, env *store.CloudEnvironment) (*getClusterJSON, error) {
-	res, err := cs.client.Do(ctx, "GET", getClusterPath+cloudClusterID, nil, env)
+	res, err := cs.client.Do(ctx, "GET", fmt.Sprintf(getClusterPath, env.TenantID, env.ProjectID, cloudClusterID), nil, env)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (cs *CloudService) addIP(ctx context.Context, clusterID, cloudClusterID, ip
 func (cs *CloudService) killCluster(ctx context.Context, clusterID, cloudClusterID string, env *store.CloudEnvironment) error {
 	log.Printf("Running cloud KillCluster for %s: %s", clusterID, cloudClusterID)
 
-	res, err := cs.client.Do(ctx, "DELETE", deleteClusterPath+cloudClusterID, nil, env)
+	res, err := cs.client.Do(ctx, "DELETE", fmt.Sprintf(deleteClusterPath, env.TenantID, env.ProjectID, cloudClusterID), nil, env)
 	if err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func (cs *CloudService) AddIP(ctx context.Context, clusterID, ip string) error {
 func (cs *CloudService) getAllClusters(ctx context.Context, env *store.CloudEnvironment) ([]*cluster.Cluster, error) {
 	// TODO: Implement pagination
 	// TODO: Support listing get all clusters across custom environments
-	res, err := cs.client.Do(ctx, "GET", getAllClustersPath+fmt.Sprintf("?perPage=1000&projectId=%s", env.ProjectID), nil, env)
+	res, err := cs.client.Do(ctx, "GET", fmt.Sprintf(getAllClustersPath, env.TenantID, env.ProjectID)+fmt.Sprintf("?perPage=100&projectId=%s", env.ProjectID), nil, env)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (cs *CloudService) getAllClusters(ctx context.Context, env *store.CloudEnvi
 	}
 
 	var clusters []*cluster.Cluster
-	for _, d := range respBody.Data.Items {
+	for _, d := range respBody.Data {
 		c, err := cs.GetCluster(ctx, d.Name)
 		if err != nil {
 			log.Printf("Failed to get cluster: %s: %v", d.Name, err)

--- a/service/cloud/constants.go
+++ b/service/cloud/constants.go
@@ -2,13 +2,12 @@ package cloud
 
 const (
 	// public API
-	deleteClusterPath  = "/v3/clusters/"
-	getClusterPath     = "/v3/clusters/"
-	getAllClustersPath = "/v3/clusters"
+	deleteClusterPath  = "/v4/organizations/%s/projects/%s/clusters/%s"
+	getClusterPath     = "/v4/organizations/%s/projects/%s/clusters/%s"
+	getAllClustersPath = "/v4/organizations/%s/projects/%s/clusters"
 	// TODO: Use public API when AV-27634 fixed
 	// createUserPath     = "/v3/clusters/%s/users"
-	clustersHealthPath = "/v3/clusters/%s/health"
-
+	clustersHealthPath = "/v3/clusters/%s/health" // TODO: Update to v4 API; v3 is no longer supported
 	// internal API
 	internalBasePath = "/v2/organizations/%s/projects/%s/clusters/%s"
 	// Need to use /deploy to use custom image

--- a/service/cloud/json.go
+++ b/service/cloud/json.go
@@ -6,9 +6,7 @@ type getAllClustersClusterJSON struct {
 }
 
 type getAllClustersJSON struct {
-	Data struct {
-		Items []getAllClustersClusterJSON `json:"items"`
-	} `json:"data"`
+	Data []getAllClustersClusterJSON `json:"data"`
 }
 
 type getClusterJSONVersion struct {


### PR DESCRIPTION
SDKQE-3565 replace capella v3 api's to v4 api's

Use Capella v4 apis wherever v3 apis are being used.

```
// public API
deleteClusterPath  = "/v3/clusters/"
getClusterPath     = "/v3/clusters/"
getAllClustersPath = "/v3/clusters"
// TODO: Use public API when AV-27634 fixed
// createUserPath     = "/v3/clusters/%s/users"
clustersHealthPath = "/v3/clusters/%s/health"
```

cluster health endpoint is only used to get bucket's health which function is not being used anywhere in cbdynclusterd, so we can either remove it if this is no longer needed or find a way to get the bucket's health using v4 api's. 
