### PR TITLE
SDKQE-3621: Fix rockylinux docker containers not being SSH'able

### DIFF
--- a/dockerfiles/couchbase/linux/Dockerfile
+++ b/dockerfiles/couchbase/linux/Dockerfile
@@ -4,7 +4,8 @@ USER root
 
 RUN mkdir /var/run/sshd
 RUN echo 'root:couchbase' | chpasswd
-RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/^#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config || \
+    echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd


### PR DESCRIPTION
Bug with enabling this in the dockerfile sshd_config update - it was not changing the correct line.