### PR TITLE
SDKQE-3669 :- fix get cluster json request ie change status to CurrentState.

### DIFF
--- a/service/cloud/json.go
+++ b/service/cloud/json.go
@@ -16,7 +16,7 @@ type getClusterJSONVersion struct {
 type getClusterJSON struct {
 	ID           string                `json:"id"`
 	ProjectID    string                `json:"projectId"`
-	Status       string                `json:"status"`
+	Status       string                `json:"currentState"`
 	Name         string                `json:"name"`
 	Version      getClusterJSONVersion `json:"version"`
 	EndpointsSRV string                `json:"endpointsSrv"`


### PR DESCRIPTION
SDKQE-3669 :- fix get cluster json request ie change status to CurrentState. 

create-cloud cluster is timing out when checking for cluster state to be in healthy state after deploying as per current v4 api of getCluster it sends with key "CurrentState" instead of "Status".